### PR TITLE
docs: backlog Sprint 1 (PO)

### DIFF
--- a/docs/Sprint1/sprint1-backlog.md
+++ b/docs/Sprint1/sprint1-backlog.md
@@ -1,0 +1,47 @@
+# Backlog Sprint 1 - Kiwisha E-Commerce Platform
+
+## Objetivo del Sprint 1
+El enfoque principal de este sprint es establecer el entorno de trabajo, las herramientas de colaboración y los estándares de desarrollo que regirán el resto del proyecto. No se incluirán funcionalidades de negocio en esta iteración.
+
+## Roles del Equipo
+- **Product Owner (PO):** Responsable de definir las historias de usuario y priorizar el backlog. Supervisa que el valor del negocio sea entregado.
+- **Scrum Master (SM):** Facilita los procesos ágiles, elimina impedimentos y asegura que el equipo siga el flujo de trabajo definido. Responsable de la protección de ramas y flujo de trabajo.
+- **Dev A:** Desarrollador senior enfocado en la estandarización y plantillas transversales del proyecto.
+- **Dev B:** Desarrollador enfocado en los procesos de cierre, evidencias y gestión de versiones (Releases).
+- **Dev C:** Desarrollador encargado de la calidad técnica y la resolución de conflictos estructurales.
+
+## Lista de Issues del Sprint 1
+
+### Tareas Técnicas
+- [S1-T01: Instalación y configuración de herramientas](https://github.com/RsalasOFF/Kiwisha/issues/1)
+- [S1-T02: Estrategia de ramificación y estándar de commits](https://github.com/RsalasOFF/Kiwisha/issues/2)
+- [S1-T03: Configuración de Branch Protection Rules](https://github.com/RsalasOFF/Kiwisha/issues/3)
+- [S1-T04: Definición de la arquitectura base](https://github.com/RsalasOFF/Kiwisha/issues/4)
+- [S1-T05: Simulación de resolución de conflictos](https://github.com/RsalasOFF/Kiwisha/issues/5)
+- [S1-T06: Creación de Pull Request Templates](https://github.com/RsalasOFF/Kiwisha/issues/6)
+- [S1-T07: Flujo de trabajo de revisión por pares (Peer Review)](https://github.com/RsalasOFF/Kiwisha/issues/7)
+- [S1-T08: Configuración de flujo de Release](https://github.com/RsalasOFF/Kiwisha/issues/8)
+- [S1-T09: Documentación de estándares de código](https://github.com/RsalasOFF/Kiwisha/issues/9)
+- [S1-T10: Gestión de evidencias del Sprint](https://github.com/RsalasOFF/Kiwisha/issues/10)
+
+### Historias de Usuario (Backlog Inicial)
+- [S1-US01 a S1-US12](https://github.com/RsalasOFF/Kiwisha/issues?q=is%3Aissue+is%3Aopen+label%3Auser-story)
+
+## Matriz de Responsabilidades (Sprint 1)
+- **SM:** S1-T03 (Branch Protection) y S1-T07 (Flujo de trabajo).
+- **Dev A:** S1-T06 (PR Templates).
+- **Dev B:** S1-T08 (Release) y S1-T10 (Evidencias).
+- **Dev C:** S1-T05 (Conflicto).
+- **PO:** Gestión de todas las Historias de Usuario y S1-T02 (Estrategia de ramas/commits).
+
+## Priorización
+- **P0 (Crítico):** S1-T06, S1-T07, S1-T03, S1-T05.
+- **P1 (Alto):** S1-T08, S1-T10, S1-T02.
+- **P2 (Medio/Bajo):** S1-T01, S1-T09 e Historias de Usuario (Backlog).
+
+## Definition of Done (DoD) Sprint 1
+- Todas las herramientas configuradas y verificadas.
+- Documentación de estándares disponible en el repositorio.
+- Branch protection activa en `main` y `develop`.
+- PR Templates funcionales.
+- Evidencias cargadas en la carpeta correspondiente.


### PR DESCRIPTION
Este PR inicializa la documentación del backlog del Sprint 1, definiendo los roles del equipo, la lista de tareas técnicas e historias de usuario, así como la priorización y el DoD del sprint.

Closes #10